### PR TITLE
Investigate scrolling issues on mobile headers

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -112,7 +112,7 @@ import { Image } from "astro:assets";
             aria-label="Introduction"
           >
           <div
-              class="sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -138,7 +138,7 @@ import { Image } from "astro:assets";
             aria-label="About me"
           >
             <div
-              class="sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -177,7 +177,7 @@ import { Image } from "astro:assets";
             aria-label="Work experience"
           >
             <div
-              class="sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -201,7 +201,7 @@ import { Image } from "astro:assets";
             aria-label="Lectures"
           >
             <div
-              class="sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -226,7 +226,7 @@ import { Image } from "astro:assets";
             aria-label="Web Applications"
           >
             <div
-              class="sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -339,6 +339,39 @@ import { Image } from "astro:assets";
     30%,
     70% {
       background-position: 0% 50%;
+    }
+  }
+
+  /* Fix for mobile sticky headers stacking issue */
+  @media (max-width: 1023px) {
+    .section-header {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      background: rgba(23, 23, 23, 0.8);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    
+    /* Ensure each section header has a unique z-index to prevent stacking */
+    #introduction .section-header {
+      z-index: 15;
+    }
+    
+    #about .section-header {
+      z-index: 14;
+    }
+    
+    #experience .section-header {
+      z-index: 13;
+    }
+    
+    #lecture .section-header {
+      z-index: 12;
+    }
+    
+    #applications .section-header {
+      z-index: 11;
     }
   }
 


### PR DESCRIPTION
Fix sticky section headers stacking on mobile screens.

Previously, all sticky headers shared the same `z-index`, leading to multiple headers overlapping when scrolling on smaller viewports. This PR assigns unique, decreasing `z-index` values to each section's sticky header to ensure they correctly replace each other as the user scrolls.