### PR TITLE
Netlify: fix redirects/forms and SkillHub icon sizing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,12 +8,20 @@
 # Redirect rules for form submissions  
 [[redirects]]
   from = "/partner-success"
-  to = "/partner/success"
-  status = 200
+  to = "/partner/success/"
+  status = 301
 
-# Catch-all redirect for SPA behavior (but preserve existing files)
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
-  conditions = {Role = ["visitor"], Country = ["!"]} 
+  from = "/partner"
+  to = "/partner/"
+  status = 301
+
+[[redirects]]
+  from = "/partner/success"
+  to = "/partner/success/"
+  status = 301
+
+[[redirects]]
+  from = "/links"
+  to = "/links/"
+  status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "npm run build"
 
 [build.environment]
-  NODE_VERSION = "20"
+  NODE_VERSION = "22.16.0"
 
 # Redirect rules for form submissions  
 [[redirects]]

--- a/src/components/SkillHub.astro
+++ b/src/components/SkillHub.astro
@@ -34,15 +34,15 @@ const marqueeItems = [...CAROUSEL_SKILLS, ...CAROUSEL_SKILLS];
         return (
           <li class="shrink-0">
             <span
-              class="group flex h-8 w-8 items-center justify-center"
+              class="group flex h-10 w-10 items-center justify-center"
               title={skill.name}
             >
               <img
                 src={iconUrl}
                 alt=""
-                width={28}
-                height={28}
-                class="h-7 w-7 object-contain opacity-65 transition-[opacity,filter] duration-200 group-hover:opacity-100 group-hover:brightness-125"
+                width={32}
+                height={32}
+                class="h-8 w-8 object-contain opacity-65 transition-[opacity,filter] duration-200 group-hover:opacity-100 group-hover:brightness-125"
                 loading="lazy"
                 decoding="async"
               />

--- a/src/components/projects/index.astro
+++ b/src/components/projects/index.astro
@@ -79,7 +79,7 @@ const showStudioLink = logo === BRAND.logoPath;
           {
             showStudioLink && (
               <p class="mt-3 text-sm">
-                <a href="/partner" class:list={[TEXT_LINK_CLASS, "md:text-neutral-300"]}>
+                <a href="/partner/" class:list={[TEXT_LINK_CLASS, "md:text-neutral-300"]}>
                   {NAV_COPY.workWithStudio} →
                 </a>
               </p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -141,7 +141,7 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
 
               <a
                 data-ccursor
-                href="/links"
+                href="/links/"
                 class={HERO_CTA_CLASS}
               >
                 <IconLinks />
@@ -225,7 +225,7 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
                 <p>
                   As Technical Lead at{" "}
                   <a
-                    href="/partner"
+                    href="/partner/"
                     class={TEXT_LINK_CLASS}
                     aria-label={BRAND.studioName}
                   >

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -104,7 +104,7 @@ const breadcrumbItems = [
           <span>{LINK_LABELS.portfolio}</span>
         </a>
 
-        <a href="/partner" class={LINK_ROW_CLASS}>
+        <a href="/partner/" class={LINK_ROW_CLASS}>
           <span class={LINK_ICON_CLASS}>
             <BrandLogo variant="icon" />
           </span>

--- a/src/pages/partner.astro
+++ b/src/pages/partner.astro
@@ -254,9 +254,9 @@ const breadcrumbItems = [
               class="mt-10 space-y-6"
               method="POST"
               name="partner-inquiry"
-              action="/partner/success"
+              action="/partner/success/"
               data-netlify="true"
-              data-netlify-honeypot="bot-field"
+              netlify-honeypot="bot-field"
             >
               <div style="display: none;">
                 <label

--- a/src/pages/partner/success.astro
+++ b/src/pages/partner/success.astro
@@ -109,7 +109,7 @@ const breadcrumbItems = [
 
           <div class="mt-10 flex flex-col justify-center gap-4 sm:flex-row">
             <a href="/" class={GLASS_BTN_PRIMARY_CLASS}>Back to homepage</a>
-            <a href="/partner" class={GLASS_BTN_CLASS}>Submit another inquiry</a>
+            <a href="/partner/" class={GLASS_BTN_CLASS}>Submit another inquiry</a>
           </div>
 
           <p class="mt-8 text-sm text-neutral-500">


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Removing the SPA fallback may break client-side routes if any exist outside static pages; partner form submission depends on correct Netlify redirect and honeypot attribute behavior.
> 
> **Overview**
> **Netlify routing** now uses **301 redirects** to trailing-slash URLs for `/partner`, `/partner/success`, and `/links`, and maps `/partner-success` to `/partner/success/`. The previous **SPA catch-all** (`/*` → `index.html`) is **removed**.
> 
> **Site links and forms** are aligned with those URLs: internal `href`s and the partner inquiry form **`action`** use trailing slashes. The partner form switches honeypot from `data-netlify-honeypot` to **`netlify-honeypot`**.
> 
> **SkillHub** marquee icons are slightly **larger** (container and image dimensions bumped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df94624cbaa9c7f7808584eb6e8e3b6afc8ce76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->