### PR TITLE
Improve resume section readability and add project demo modal

### DIFF
--- a/src/components/experience/props.ts
+++ b/src/components/experience/props.ts
@@ -4,6 +4,7 @@ export interface Props {
   company: string;
   companyUrl: string;
   description: string;
+  tldr: string;
   highlights?: string[];
   technologies: string[];
   logo?: string;

--- a/src/components/projects/index.astro
+++ b/src/components/projects/index.astro
@@ -8,11 +8,11 @@ const { title, projectUrl, description, tags, logo, type } = Astro.props;
 const showStudioLink = logo === BRAND.logoPath;
 ---
 
-<li class="group mb-3 sm:mb-8 last:mb-0">
+<li class="group mb-3 sm:mb-8 lg:mb-0 last:mb-0">
   <section
     class="overflow-hidden relative transition-all lg:hover:!opacity-100 lg:group-hover/list:opacity-50 duration-500 
            sm:pr-8 sm:h-[20rem] sm:grid sm:grid-cols-8 sm:gap-8 md:gap-4
-           md:h-[24rem] md:grid-cols-1 md:gap-0 md:cursor-pointer"
+           md:h-[24rem] md:grid-cols-1 md:gap-0 md:cursor-pointer lg:h-[20rem] lg:pr-4"
   >
     <div
       class="absolute -inset-x-4 -inset-y-4 z-0 hidden rounded-md transition motion-reduce:transition-none lg:-inset-x-6 lg:block lg:group-hover:bg-neutral-800/50 lg:group-hover:shadow-[inset_0_1px_0_0_rgb(148_163_184/0.1)] lg:group-hover:drop-shadow-lg"
@@ -41,7 +41,7 @@ const showStudioLink = logo === BRAND.logoPath;
       class="py-4 px-5 sm:pl-10 sm:pr-2 sm:pt-10 sm:max-w-[65%] sm:col-start-1 flex flex-col h-full sm:col-span-6 sm:group-even:col-start-6 sm:group-even:max-w-full
              md:absolute md:inset-0 md:z-30 md:max-w-none md:p-8 md:bg-gradient-to-t md:from-black/90 md:via-black/50 md:to-transparent 
              md:opacity-0 md:group-hover:opacity-100 md:transition-all md:duration-500 md:backdrop-blur-sm
-             md:justify-end md:pointer-events-none"
+             md:justify-end md:pointer-events-none lg:p-6"
     >
       <div class="md:pointer-events-auto">
         <h3 class="z-10 font-medium leading-snug text-neutral-200 md:text-white">

--- a/src/components/projects/props.ts
+++ b/src/components/projects/props.ts
@@ -5,4 +5,6 @@ export interface Props {
   tags: string[];
   logo?: string;
   type: string;
+  forCompany?: string;
+  muxPlaybackId?: string;
 }

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -9,6 +9,7 @@ export const EXPERIENCE: ExperienceProp[] = [
     companyUrl: "/partner",
     description:
       "Reduce client dependency on fragmented manual workflows by building centralized operational tooling, automation systems, and custom web platforms tailored to day-to-day business operations.",
+    tldr: "Build full-stack operational software for SMBs: websites that drive leads, and tools that replace spreadsheets/paper with real workflows.",
     highlights: [
       "Northwestern Integrity Builders (builtbynib.com): launched the company's first digital platform, turning a word-of-mouth construction business into an online lead-generation pipeline; building a full-stack quoting platform that calculates estimates from material, labor, and time inputs and outputs formatted PDF quotes.",
       "MMC Communications: designed and deployed a production website optimized for trust, discoverability, and inbound inquiries; replacing paper clipboard checklists with a digital on-site audit tool for multi-building security inspections (in development).",
@@ -30,6 +31,7 @@ export const EXPERIENCE: ExperienceProp[] = [
     companyUrl: "https://www.spokaneeye.com/",
     description:
       "Build production internal tools that streamline clinical onboarding, training, and ophthalmic supply workflows.",
+    tldr: "Ship internal tools used by staff: onboarding/training systems and inventory workflows that remove tribal knowledge and interruptions.",
     highlights: [
       "TransposeRx: replaced inconsistent verbal training with a production LMS featuring structured lessons, quizzes, and progress tracking; designed MDX-based lesson architecture so new modules ship without schema migrations.",
       "Kit Tracker: centralized procedure supply tracking with QR-labeled bins, camera scanning, and full-text search, deployed and actively used in clinical operations.",
@@ -50,6 +52,7 @@ export const EXPERIENCE: ExperienceProp[] = [
     companyUrl: "https://www.idurology.com/",
     description:
       "Replaced inconsistent verbal-only onboarding with the clinic's first structured scribe training system, creating a repeatable process that remained after departure.",
+    tldr: "Built a durable onboarding/training system to standardize scribe workflows and make ramp-up repeatable.",
     highlights: [
       "Documented workflows, expectations, and operational standards that improved onboarding consistency and long-term knowledge transfer.",
     ],

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -10,6 +10,7 @@ export const PROJECTS: ProjectProp[] = [
       "Production inventory tool for ophthalmic procedure supplies with QR-labeled bins, camera scanning, and full-text search replacing tribal knowledge and repeated staff interruptions.",
     tags: ["React", "TypeScript", "Railway", "Clinical Ops"],
     logo: "/logos/sec.webp",
+    forCompany: "Spokane Eye Clinic",
   },
   {
     title: "TransposeRx",
@@ -19,6 +20,7 @@ export const PROJECTS: ProjectProp[] = [
       "Production LMS for ophthalmic technician onboarding with structured lessons, quizzes, progress tracking, and MDX-based curriculum that scales without schema migrations.",
     tags: ["React", "MDX", "Railway"],
     logo: "/logos/transposerx.gif",
+    forCompany: "Spokane Eye Clinic",
   },
   {
     title: "Built by NIB",
@@ -28,6 +30,7 @@ export const PROJECTS: ProjectProp[] = [
       "First digital platform for Northwestern Integrity Builders: online lead generation for a word-of-mouth construction business, with a quoting system in development for automated PDF estimates.",
     tags: ["Astro", "TypeScript", "Tailwind CSS"],
     logo: BRAND.logoPath,
+    forCompany: "Twin Rocks Software Studio",
   },
   {
     title: "MMC Communications",
@@ -37,5 +40,6 @@ export const PROJECTS: ProjectProp[] = [
       "Production marketing site built for trust, discoverability, and inbound inquiries; digital on-site security audit tool in development to replace paper clipboard checklists.",
     tags: ["Astro", "TypeScript", "Tailwind CSS"],
     logo: BRAND.logoPath,
+    forCompany: "Twin Rocks Software Studio",
   },
 ];

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -259,6 +259,7 @@ const getProjectsForCompany = (company: string) =>
                 {
                   EXPERIENCE.map((exp) => {
                     const expProjects = getProjectsForCompany(exp.company);
+                    const isInternalCompanyLink = exp.companyUrl.startsWith("/");
 
                     return (
                       <li>
@@ -271,7 +272,17 @@ const getProjectsForCompany = (company: string) =>
                                 </p>
                                 <h3 class="mt-1 text-base font-medium text-neutral-200">
                                   {exp.title} ·{" "}
-                                  <span class="text-neutral-300">{exp.company}</span>
+                                  <a
+                                    href={exp.companyUrl}
+                                    class={`${TEXT_LINK_CLASS} text-neutral-300 hover:text-neutral-100`}
+                                    {...(isInternalCompanyLink
+                                      ? {}
+                                      : { target: "_blank", rel: "noreferrer" })}
+                                    aria-label={`${exp.title} at ${exp.company}`}
+                                    onclick="event.stopPropagation()"
+                                  >
+                                    {exp.company}
+                                  </a>
                                 </h3>
                                 <p class="mt-2 text-sm leading-relaxed text-neutral-300">
                                   <span class="font-semibold text-neutral-200">TL;DR:</span>{" "}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,7 @@
 ---
 import SocialLinks from "../components/SocialLinks.astro";
-import Experience from "../components/experience/index.astro";
-import Project from "../components/projects/index.astro";
 import { EXPERIENCE } from "../data/experience";
 import { PROJECTS } from "../data/projects";
-import { EDUCATION } from "../data/education";
 import { CERTIFICATIONS } from "../data/certifications";
 import Layout from "../layouts/Layout.astro";
 import SkillHub from "../components/SkillHub.astro";
@@ -19,6 +16,9 @@ import profileImage from "../../public/profile.png";
 
 const transposeRxProject = PROJECTS.find((p) => p.title === "TransposeRx");
 const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
+
+const getProjectsForCompany = (company: string) =>
+  PROJECTS.filter((p) => p.forCompany === company);
 ---
 
 <Layout 
@@ -161,7 +161,7 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
           <!-- Introduction Section -->
           <section
             id="introduction"
-            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-4 lg:scroll-mt-24 "
+            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-10 lg:scroll-mt-24 "
             aria-label="Introduction"
           >
           <div
@@ -173,18 +173,17 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
                 Introduction
               </h2>
             </div>
-            <div>
-              <div>
-                <p class="text-lg font-medium leading-relaxed">
-                  {PROFILE.intro}
-                </p>
-              </div>
+            <div class="lg:rounded-2xl lg:border lg:border-neutral-800/70 lg:bg-neutral-950/20 lg:p-6 lg:shadow-sm lg:shadow-black/20">
+              <p class="text-lg font-medium leading-relaxed">
+                {PROFILE.intro}
+              </p>
+            </div>
           </section>
 
           <!-- About Me Section -->
           <section
             id="about"
-            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-4 lg:scroll-mt-18"
+            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-10 lg:scroll-mt-18"
             aria-label="About me"
           >
             <div
@@ -196,10 +195,10 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
                 About
               </h2>
             </div>
-            <div>
-              <div class="mb-4 space-y-4">
+            <div class="lg:rounded-2xl lg:border lg:border-neutral-800/70 lg:bg-neutral-950/20 lg:p-6 lg:shadow-sm lg:shadow-black/20">
+              <div class="space-y-4">
                 
-                <p>
+                <p class="text-lg font-medium leading-relaxed">
                   After earning my B.S. in Biochemistry from Whitworth University, I started in healthcare as a medical scribe at Idaho Urology Institute, where I built the clinic's first structured training system. That work led me into clinical operations at Spokane Eye Clinic, where I ship production tools like{" "}
                   <a
                     href={transposeRxProject!.projectUrl}
@@ -222,7 +221,7 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
                   </a>{" "}
                   (QR-based inventory for procedure supplies).
                 </p>
-                <p>
+                <p class="text-lg font-medium leading-relaxed">
                   As Technical Lead at{" "}
                   <a
                     href="/partner/"
@@ -233,7 +232,7 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
                   </a>
                   , I partner with small and medium businesses to replace manual spreadsheets, paper checklists, and word-of-mouth-only workflows with centralized platforms, from lead-generation sites to quoting systems and field audit tools.
                 </p>
-                <p>
+                <p class="text-lg font-medium leading-relaxed">
                   I'm open to roles where software directly improves how teams operate day to day.
                 </p>
               </div>
@@ -243,7 +242,7 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
           <!-- Experience -->
           <section
             id="experience"
-            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-4 lg:scroll-mt-24"
+            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-10 lg:scroll-mt-24"
             aria-label="Work experience"
           >
             <div
@@ -254,72 +253,136 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
               >
                 Experience
               </h2>
-            </div><div>
-              <ol class="group/list space-y-12">
-                {EXPERIENCE.map((experience) => <Experience {...experience} />)}
+            </div>
+            <div class="lg:rounded-2xl lg:border lg:border-neutral-800/70 lg:bg-neutral-950/20 lg:p-6 lg:shadow-sm lg:shadow-black/20">
+              <ol class="group/list space-y-4 lg:space-y-6">
+                {
+                  EXPERIENCE.map((exp) => {
+                    const expProjects = getProjectsForCompany(exp.company);
+
+                    return (
+                      <li>
+                        <details class="group rounded-xl border border-neutral-800/70 bg-neutral-950/30 px-5 py-4 transition-[box-shadow,border-color] lg:px-6 lg:py-5 lg:border-neutral-700/70 lg:shadow-lg lg:shadow-black/30">
+                          <summary class="cursor-pointer list-none">
+                            <div class="flex items-start justify-between gap-6">
+                              <div>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                                  {exp.dates}
+                                </p>
+                                <h3 class="mt-1 text-base font-medium text-neutral-200">
+                                  {exp.title} ·{" "}
+                                  <span class="text-neutral-300">{exp.company}</span>
+                                </h3>
+                                <p class="mt-2 text-sm leading-relaxed text-neutral-300">
+                                  <span class="font-semibold text-neutral-200">TL;DR:</span>{" "}
+                                  {exp.tldr}
+                                </p>
+                              </div>
+                              <span class="mt-1 shrink-0 rounded-full border border-neutral-800/70 bg-neutral-900/40 px-3 py-1 text-xs font-medium text-neutral-300 transition group-open:bg-neutral-900/60">
+                                Expand
+                              </span>
+                            </div>
+                          </summary>
+
+                          <div class="mt-5 space-y-4 lg:mt-6 lg:space-y-5">
+                            <div class="rounded-xl border border-neutral-800/60 bg-neutral-900/20 p-4 lg:p-5">
+                              <p class="text-xs font-semibold uppercase tracking-widest text-neutral-500">
+                                Details
+                              </p>
+
+                              <p class="mt-3 text-sm leading-relaxed text-neutral-400">
+                                {exp.description}
+                              </p>
+
+                              {
+                                exp.highlights?.length ? (
+                                  <ul class="mt-4 space-y-2 text-sm leading-relaxed text-neutral-400">
+                                    {exp.highlights.map((h) => (
+                                      <li class="flex gap-2">
+                                        <span class="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-neutral-600" />
+                                        <span>{h}</span>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                ) : null
+                              }
+
+                              {
+                                exp.technologies?.length ? (
+                                  <div class="mt-4">
+                                    <p class="text-xs font-semibold uppercase tracking-widest text-neutral-500">
+                                      Stack
+                                    </p>
+                                    <ul class="mt-2 flex flex-wrap" aria-label="Technologies used">
+                                      {exp.technologies.map((t) => (
+                                        <li class="mr-1.5 mt-2">
+                                          <div class="flex items-center rounded-full border border-neutral-800/70 bg-neutral-950/30 px-3 py-1 text-xs font-medium leading-5 text-neutral-300">
+                                            {t}
+                                          </div>
+                                        </li>
+                                      ))}
+                                    </ul>
+                                  </div>
+                                ) : null
+                              }
+                            </div>
+
+                            <div class="rounded-xl border border-neutral-800/60 bg-neutral-900/20 p-4 lg:p-5">
+                              <div class="flex items-center justify-between">
+                                <p class="text-xs font-semibold uppercase tracking-widest text-neutral-500">
+                                  Built
+                                </p>
+                                <p class="text-xs text-neutral-600">click a card for demo</p>
+                              </div>
+
+                              <div class="mt-3 grid gap-3">
+                                {expProjects.length ? (
+                                  expProjects.map((p) => (
+                                    <button
+                                      type="button"
+                                      class="js-demo-open w-full rounded-xl border border-neutral-800/70 bg-neutral-950/30 p-4 text-left transition hover:border-neutral-700/80 hover:bg-neutral-900/40"
+                                      data-title={p.title}
+                                      data-description={p.description}
+                                      data-url={p.projectUrl}
+                                      data-mux-playback-id={p.muxPlaybackId ?? ""}
+                                    >
+                                      <div class="flex items-start justify-between gap-4">
+                                        <div>
+                                          <p class="text-sm font-semibold text-neutral-100">
+                                            {p.title}
+                                          </p>
+                                          <p class="mt-1 text-xs leading-relaxed text-neutral-400">
+                                            {p.description}
+                                          </p>
+                                        </div>
+                                        <span class="shrink-0 rounded-full border border-neutral-800/70 bg-neutral-900/40 px-2.5 py-1 text-[11px] font-semibold text-neutral-200">
+                                          Watch demo
+                                        </span>
+                                      </div>
+                                      <div class="mt-3 flex flex-wrap gap-1.5">
+                                        {p.tags.slice(0, 4).map((tag) => (
+                                          <span class="rounded-full border border-neutral-800/70 bg-neutral-900/30 px-2 py-0.5 text-[11px] font-medium text-neutral-300">
+                                            {tag}
+                                          </span>
+                                        ))}
+                                      </div>
+                                    </button>
+                                  ))
+                                ) : (
+                                  <p class="mt-2 text-sm text-neutral-600">
+                                    No linked projects yet.
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </details>
+                      </li>
+                    );
+                  })
+                }
               </ol>
             </div>
-          </section>
-
-          <!-- Featured Projects -->
-          <section
-            id="applications"
-            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-36 lg:scroll-mt-24"
-            aria-label="Web Applications"
-          >
-            <div
-              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
-            >
-              <h2
-                class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
-              >
-                Featured Projects
-              </h2>
-            </div>
-            <div>
-              <ol class="group/list space-y-12">
-                {PROJECTS.map((project) => <Project {...project} />)}
-              </ol>
-            </div>
-          </section>
-
-          <!-- Education -->
-          <section
-            id="education"
-            class="mb-16 scroll-mt-16 md:mb-24 lg:mb-4 lg:scroll-mt-24"
-            aria-label="Education"
-          >
-            <div
-              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
-            >
-              <h2
-                class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
-              >
-                Education
-              </h2>
-            </div>
-            <ol class="space-y-6">
-              {
-                EDUCATION.map((entry) => (
-                  <li>
-                    <p class="text-xs font-semibold uppercase tracking-wide text-neutral-500">
-                      {entry.dates}
-                    </p>
-                    <h3 class="mt-1 font-medium text-neutral-200">
-                      <a
-                        href={entry.schoolUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        class="hover:text-neutral-300"
-                      >
-                        {entry.school}
-                      </a>
-                      <span class="text-neutral-400"> · {entry.degree}</span>
-                    </h3>
-                  </li>
-                ))
-              }
-            </ol>
           </section>
 
           <!-- Certifications -->
@@ -337,28 +400,30 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
                 Certifications
               </h2>
             </div>
-            <ol class="space-y-6">
-              {
-                CERTIFICATIONS.map((cert) => (
-                  <li>
-                    <p class="text-xs font-semibold uppercase tracking-wide text-neutral-500">
-                      {cert.dates}
-                    </p>
-                    <h3 class="mt-1 font-medium text-neutral-200">
-                      <a
-                        href={cert.credentialUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        class="hover:text-neutral-300"
-                      >
-                        {cert.name}
-                      </a>
-                      <span class="text-neutral-400"> · {cert.issuer}</span>
-                    </h3>
-                  </li>
-                ))
-              }
-            </ol>
+            <div class="lg:rounded-2xl lg:border lg:border-neutral-800/70 lg:bg-neutral-950/20 lg:p-6 lg:shadow-sm lg:shadow-black/20">
+              <ol class="space-y-6">
+                {
+                  CERTIFICATIONS.map((cert) => (
+                    <li>
+                      <p class="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                        {cert.dates}
+                      </p>
+                      <h3 class="mt-1 font-medium text-neutral-200">
+                        <a
+                          href={cert.credentialUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          class="hover:text-neutral-300"
+                        >
+                          {cert.name}
+                        </a>
+                        <span class="text-neutral-400"> · {cert.issuer}</span>
+                      </h3>
+                    </li>
+                  ))
+                }
+              </ol>
+            </div>
           </section>
           <footer class="max-w-md pb-16 text-sm text-neutral-500 sm:pb-0">
             <p>
@@ -383,12 +448,113 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
     </div>
   </div>
 
+  <dialog
+    id="project-demo-modal"
+    class="backdrop:bg-black/70 m-auto w-[min(52rem,calc(100vw-2rem))] rounded-2xl border border-neutral-800/80 bg-neutral-950 p-0 text-neutral-100"
+  >
+    <div class="border-b border-neutral-800/70 px-5 py-4">
+      <div class="flex items-start justify-between gap-4">
+        <div>
+          <p class="text-xs font-semibold uppercase tracking-widest text-neutral-500">
+            Project demo
+          </p>
+          <h3 id="project-demo-title" class="mt-1 text-lg font-semibold"></h3>
+          <p id="project-demo-description" class="mt-2 text-sm leading-relaxed text-neutral-400"></p>
+        </div>
+        <button
+          type="button"
+          class="js-demo-close rounded-full border border-neutral-800/70 bg-neutral-900/40 px-3 py-1.5 text-xs font-semibold text-neutral-200 hover:bg-neutral-900/60"
+          aria-label="Close modal"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+
+    <div class="px-5 py-5">
+      <div class="aspect-video w-full rounded-xl border border-neutral-800/70 bg-neutral-900/20 p-4">
+        <div class="flex h-full flex-col items-center justify-center text-center">
+          <div class="flex h-12 w-12 items-center justify-center rounded-full border border-neutral-700/70 bg-neutral-900/50 text-neutral-200">
+            ▶
+          </div>
+          <p class="mt-3 text-sm font-medium text-neutral-200">Mux demo video (coming soon)</p>
+          <p class="mt-1 text-xs text-neutral-500">
+            When you upload, we’ll drop in the Mux playback id and render the player here.
+          </p>
+        </div>
+      </div>
+
+      <div class="mt-4 flex flex-wrap items-center gap-3">
+        <a
+          id="project-demo-visit"
+          href="#"
+          target="_blank"
+          rel="noreferrer"
+          class="inline-flex items-center gap-2 rounded-md border border-neutral-700/60 bg-neutral-400/10 px-3.5 py-2.5 text-sm font-semibold text-neutral-100 transition hover:border-neutral-500/60 hover:bg-neutral-400/15"
+        >
+          Visit project →
+        </a>
+        <p class="text-xs text-neutral-600">
+          (Demo modal replaces direct navigation so you can show video first.)
+        </p>
+      </div>
+    </div>
+  </dialog>
+
   <footer class="relative z-10 border-t border-neutral-800/60 text-center py-10 px-6">
     <SocialLinks />
     <p class="mt-6 text-xs text-neutral-500">
       {new Date().getFullYear()}. All rights reserved.
     </p>
   </footer>
+
+  <script is:inline>
+    const modal = document.getElementById("project-demo-modal");
+    const titleEl = document.getElementById("project-demo-title");
+    const descEl = document.getElementById("project-demo-description");
+    const visitEl = document.getElementById("project-demo-visit");
+
+    function openDemoModal(button) {
+      const title = button?.dataset?.title ?? "";
+      const description = button?.dataset?.description ?? "";
+      const url = button?.dataset?.url ?? "#";
+
+      if (titleEl) titleEl.textContent = title;
+      if (descEl) descEl.textContent = description;
+      if (visitEl) visitEl.setAttribute("href", url);
+
+      if (modal && typeof modal.showModal === "function") modal.showModal();
+    }
+
+    function closeDemoModal() {
+      if (modal && typeof modal.close === "function") modal.close();
+    }
+
+    document.addEventListener("click", (e) => {
+      const openBtn = e.target?.closest?.(".js-demo-open");
+      if (openBtn) {
+        e.preventDefault();
+        openDemoModal(openBtn);
+        return;
+      }
+
+      const closeBtn = e.target?.closest?.(".js-demo-close");
+      if (closeBtn) {
+        e.preventDefault();
+        closeDemoModal();
+      }
+    });
+
+    if (modal) {
+      modal.addEventListener("click", (e) => {
+        if (e.target === modal) closeDemoModal();
+      });
+      modal.addEventListener("cancel", (e) => {
+        e.preventDefault();
+        closeDemoModal();
+      });
+    }
+  </script>
 </Layout>
 
 <style scoped>
@@ -450,14 +616,6 @@ const kitTrackerProject = PROJECTS.find((p) => p.title === "Kit Tracker");
     
     #experience .section-header {
       z-index: 13;
-    }
-
-    #applications .section-header {
-      z-index: 12;
-    }
-
-    #education .section-header {
-      z-index: 11;
     }
 
     #certifications .section-header {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Marketing-site layout and content presentation only; no auth, APIs, or data persistence changes beyond optional future Mux IDs.
> 
> **Overview**
> The homepage **resume narrative is reorganized** so work and deliverables read together: each job is an expandable **`<details>`** card with a new **TL;DR** line, full details/highlights/stack inside, and **projects linked by employer** (`forCompany`) instead of a separate Featured Projects list.
> 
> **Education** and the standalone **Featured Projects** section are **removed from `index.astro`** (education data remains in the repo but is no longer rendered on the home page). Project cards under each role open a **`<dialog>` demo modal** (inline script) with title/description and a **Visit project** link; **Mux playback** is stubbed (`muxPlaybackId` on project props, placeholder player copy).
> 
> Intro/About/Certifications/Experience gain **large-screen card framing** (borders, padding, spacing tweaks). The old **`Experience` / `Project` Astro components** are no longer used on the home page; project list styling in `projects/index.astro` gets minor **lg layout** adjustments only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea57dfd38a43ce71a6a02928e5f5e8ec6215971e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->