### PR TITLE
Align links page with home hero and fix mobile scroll jitter.

### DIFF
--- a/src/components/CoffeeChatButton.tsx
+++ b/src/components/CoffeeChatButton.tsx
@@ -10,7 +10,7 @@ export default function CoffeeChatButton() {
   const closeCal = () => setIsCalOpen(false);
 
   return (
-    <>
+    <div className="w-full">
       <button
         type="button"
         onClick={openCal}
@@ -24,6 +24,6 @@ export default function CoffeeChatButton() {
       </button>
 
       <CalEmbed isOpen={isCalOpen} onClose={closeCal} />
-    </>
+    </div>
   );
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,6 +20,10 @@ const getProjectsForCompany = (company: string) =>
 const titleMatch = PROFILE.title.match(/^(.+)\s+(\S+)$/);
 const titleLead = titleMatch?.[1] ?? PROFILE.title;
 const titleAccent = titleMatch?.[2];
+
+/** Mobile section labels — static (not sticky) to avoid sticky handoff jitter */
+const SECTION_HEADER_CLASS =
+  "section-header -mx-6 mb-4 px-6 py-3 md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0";
 ---
 
 <Layout 
@@ -163,7 +167,7 @@ const titleAccent = titleMatch?.[2];
             aria-label="Introduction"
           >
           <div
-              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class={SECTION_HEADER_CLASS}
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -185,7 +189,7 @@ const titleAccent = titleMatch?.[2];
             aria-label="About me"
           >
             <div
-              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class={SECTION_HEADER_CLASS}
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -244,7 +248,7 @@ const titleAccent = titleMatch?.[2];
             aria-label="Work experience"
           >
             <div
-              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class={SECTION_HEADER_CLASS}
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -401,7 +405,7 @@ const titleAccent = titleMatch?.[2];
             aria-label="Certifications"
           >
             <div
-              class="section-header sticky top-0 z-20 -mx-6 mb-4 w-screen px-6 py-3 backdrop-blur-lg md:-mx-12 md:px-12 lg:sr-only lg:relative lg:top-auto lg:mx-auto lg:w-full lg:px-0 lg:py-0 lg:opacity-0"
+              class={SECTION_HEADER_CLASS}
             >
               <h2
                 class="text-sm font-bold uppercase tracking-widest text-neutral-200 lg:sr-only"
@@ -580,8 +584,6 @@ const titleAccent = titleMatch?.[2];
     background-image: url(/pattern.svg);
     background-position: top center;
     background-repeat: no-repeat;
-    overflow-y: visible;
-    overflow-x: clip;
   }
 
   .shiny-sec {
@@ -603,32 +605,11 @@ const titleAccent = titleMatch?.[2];
     }
   }
 
-  /* Fix for mobile sticky headers stacking issue */
+  /* Static section labels on mobile/tablet — avoids sticky handoff bounce */
   @media (max-width: 1023px) {
     .section-header {
-      position: sticky;
-      top: 0;
-      z-index: 10;
-      background: rgba(23, 23, 23, 0.8);
-      backdrop-filter: blur(12px);
-      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    }
-    
-    /* Ensure each section header has a unique z-index to prevent stacking */
-    #introduction .section-header {
-      z-index: 15;
-    }
-    
-    #about .section-header {
-      z-index: 14;
-    }
-    
-    #experience .section-header {
-      z-index: 13;
-    }
-
-    #certifications .section-header {
-      z-index: 9;
+      background: rgb(23 23 23 / 0.92);
+      border-bottom: 1px solid rgb(255 255 255 / 0.1);
     }
   }
 

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -5,11 +5,14 @@ import IconLinkedin from "../components/icons/linkedin.astro";
 import CoffeeChatButton from "../components/CoffeeChatButton";
 import SocialLinks from "../components/SocialLinks.astro";
 import { Image } from "astro:assets";
-import profileImage from "../../public/profile.png";
 import rmLogo from "../../public/logos/rcmcodes_white.svg";
 import BrandLogo from "../components/BrandLogo.astro";
 import { PROFILE } from "../data/profile";
 import { LINK_LABELS, LINK_ROW_CLASS, LINK_ICON_CLASS } from "../data/contact";
+
+const titleMatch = PROFILE.title.match(/^(.+)\s+(\S+)$/);
+const titleLead = titleMatch?.[1] ?? PROFILE.title;
+const titleAccent = titleMatch?.[2];
 
 const breadcrumbItems = [
   { label: "Home", href: "/" },
@@ -53,27 +56,33 @@ const breadcrumbItems = [
       <Breadcrumbs items={breadcrumbItems} class="w-full" />
 
       <header class="mb-8 text-center">
-        <Image
-          src={profileImage}
-          alt={PROFILE.imageAlt}
-          class="mx-auto h-24 w-24 rounded-xl object-cover ring-2 ring-neutral-700/80 pixelated"
-          width={192}
-          height={192}
-          loading="eager"
-          decoding="async"
-          fetchpriority="high"
-        />
+        <div class="flex flex-col items-center gap-3">
+          <img
+            src="/sunglasses_dev.svg"
+            alt="Pixel art avatar with speech bubble Hi I'm Roberto"
+            class="mx-auto w-full max-w-[12rem] pixelated sm:max-w-[14rem]"
+            width={1024}
+            height={1024}
+            loading="eager"
+            decoding="async"
+            fetchpriority="high"
+          />
 
-        <h1
-          class="mt-6 inline-block rounded-full bg-neutral-400/10 px-3 py-1 text-sm font-medium text-neutral-200/80"
-        >
-          Connect with {PROFILE.displayName}
-        </h1>
-
-        <p class="mt-3 text-sm text-neutral-400">{PROFILE.title}</p>
-        <p class="mt-2 px-2 text-xs leading-relaxed text-neutral-500">
-          {PROFILE.focus}
-        </p>
+          <div class="flex flex-col items-center gap-2 max-w-sm">
+            <h1 class="text-2xl font-medium tracking-tight sm:text-3xl">
+              <span class="hero-title-lead">{titleLead}</span>
+              {titleAccent && (
+                <>
+                  {" "}
+                  <span class="hero-title-accent">{titleAccent}</span>
+                </>
+              )}
+            </h1>
+            <p class="px-2 text-sm font-normal leading-relaxed text-neutral-400">
+              {PROFILE.focus}
+            </p>
+          </div>
+        </div>
       </header>
 
       <div
@@ -84,7 +93,7 @@ const breadcrumbItems = [
         </p>
       </div>
 
-      <nav class="mb-10 space-y-3" aria-label="Professional links">
+      <nav class="mb-10 flex flex-col gap-3" aria-label="Professional links">
         <a
           href="https://rcmcodes.com"
           target="_blank"
@@ -147,6 +156,7 @@ const breadcrumbItems = [
 
 <style>
   .links-hub {
+    font-family: var(--font-geist-sans);
     background-image: url(/pattern.svg);
     background-position: top center;
     background-repeat: no-repeat;


### PR DESCRIPTION
Match links profile to SVG/Geist styling, fix link row spacing for the coffee chat island, and use static section labels on small screens to remove sticky handoff bounce.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout and CSS changes on marketing pages; no auth, data, or API behavior.
> 
> **Overview**
> **Links hub** now mirrors the home hero: pixel **SVG** avatar, split **title** styling (`hero-title-lead` / `hero-title-accent`), **Geist** sans on `.links-hub`, and a **flex column** nav with consistent **gap** so rows (including coffee chat) align cleanly. **Coffee chat** is wrapped in a full-width **`div`** so it behaves like other link rows in that layout.
> 
> On the **home page**, mobile/tablet **section labels** are no longer **sticky**—shared **`SECTION_HEADER_CLASS`** replaces per-section sticky/backdrop stacks, and related **hero overflow** and layered **z-index** sticky CSS is removed to stop scroll **handoff jitter** while keeping simple label chrome on small screens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 493df0e9e70d1e3ecdcfad5402602476937eef50. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->